### PR TITLE
Add Claude Code support via .claude-plugin manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,42 @@
+{
+  "name": "Spec2Cloud",
+  "owner": {
+    "name": "Azure Samples"
+  },
+  "metadata": {
+    "description": "Spec2Cloud marketplace plugins for Claude Code.",
+    "version": "1.2.0"
+  },
+  "plugins": [
+    {
+      "name": "speckit",
+      "source": "./plugins/speckit-spec2cloud",
+      "description": "Spec-driven workflow for shipping to Azure with Spec-Kit: constitution → specify → clarify → plan → tasks → implement → verify → deploy.",
+      "version": "1.2.0",
+      "homepage": "https://github.com/Azure-Samples/Spec2Cloud",
+      "keywords": [
+        "azure",
+        "cloud",
+        "infrastructure",
+        "deployment",
+        "microsoft",
+        "devops"
+      ]
+    },
+    {
+      "name": "lean",
+      "source": "./plugins/lean-spec2cloud",
+      "description": "Lean spec-driven workflow for shipping to Azure: specify → plan → implement → verify → deploy.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/Azure-Samples/Spec2Cloud",
+      "keywords": [
+        "azure",
+        "cloud",
+        "infrastructure",
+        "deployment",
+        "microsoft",
+        "devops"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -90,6 +90,31 @@ Use the Lean Toolkit when you want a fast, low-overhead workflow in Copilot.
 
 ---
 
+### 🤖 Use with Claude Code
+
+The `lean` and `speckit` plugins also install in [Claude Code](https://claude.com/claude-code). The skills are the same source as the Copilot plugins — only the manifests differ — so the workflow is identical.
+
+1. **Add the marketplace and install a plugin:**
+
+   ```text
+   /plugin marketplace add Azure-Samples/Spec2Cloud
+   /plugin install lean@Spec2Cloud
+   ```
+
+   Swap `lean` for `speckit` to install the fuller Spec Kit workflow instead.
+
+2. **Run the stages** (same prerequisites as the Lean Toolkit above — `az`, `azd`, `bicep`, and `azd auth login`):
+
+   ```text
+   /lean:specify Build a todo web app with a C# backend deployed on App Service, using Cosmos DB for NoSQL as the data persistence layer.
+   /lean:plan
+   /lean:implement
+   /lean:verify
+   /lean:deploy
+   ```
+
+---
+
 ### 🔧 VS Code Extension
 
 Use the Spec2Cloud Toolkit extension to monitor spec-driven workflow progress and scaffold projects from templates directly in VS Code. It complements Copilot CLI workflows with a guided visual experience.

--- a/plugins/lean-spec2cloud/.claude-plugin/plugin.json
+++ b/plugins/lean-spec2cloud/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "lean-spec2cloud",
+  "description": "Lean spec-driven workflow for shipping to Azure: specify → plan → implement → verify → deploy.",
+  "version": "1.0.0",
+  "author": { "name": "Azure Samples" },
+  "homepage": "https://github.com/Azure-Samples/Spec2Cloud"
+}

--- a/plugins/speckit-spec2cloud/.claude-plugin/plugin.json
+++ b/plugins/speckit-spec2cloud/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "speckit-spec2cloud",
+  "description": "Spec-driven workflow for shipping to Azure: constitution → specify → clarify → plan → tasks → implement → verify → deploy.",
+  "version": "1.2.0",
+  "author": { "name": "Azure Samples" },
+  "homepage": "https://github.com/Azure-Samples/Spec2Cloud"
+}


### PR DESCRIPTION
## Summary

Makes the `lean` and `speckit` plugins installable in [Claude Code](https://claude.com/claude-code) alongside the existing GitHub Copilot support, **without changing any skill content**. The `SKILL.md` files are already in the portable format Claude Code reads natively — the only gap was the manifest location (Claude Code uses `.claude-plugin/`, this repo uses the Copilot convention `.github/plugin/`).

Resolves #12.

## Changes (purely additive)

- **`/.claude-plugin/marketplace.json`** — root marketplace, ported from `.github/plugin/marketplace.json`, so users can run `/plugin marketplace add Azure-Samples/Spec2Cloud` in Claude Code.
- **`plugins/lean-spec2cloud/.claude-plugin/plugin.json`** and **`plugins/speckit-spec2cloud/.claude-plugin/plugin.json`** — per-plugin manifests mirroring the existing `.github/plugin/plugin.json` files.
- **`README.md`** — new "Use with Claude Code" section documenting the install commands.

The existing `skills/` directories are auto-discovered by Claude Code, so no skill files change. The Copilot (`.github/plugin/...`) and VS Code paths are untouched.

## How to test

In Claude Code:

```text
/plugin marketplace add Azure-Samples/Spec2Cloud
/plugin install lean@Spec2Cloud
/lean:specify Build a todo web app ...
```

(Swap `lean` for `speckit` for the fuller workflow.)

## Notes / possible follow-ups (not in this PR)

- A `package-*-claude-plugin` skill mirroring the existing `package-speckit-spec2cloud-plugin` skill, to keep the Claude manifests generated/in-sync with source.
- Neutralizing the few Copilot-only content references (`/fleet` usage, also emitting `CLAUDE.md` next to `.github/copilot-instructions.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)